### PR TITLE
Add corvus-jsonschema library details

### DIFF
--- a/libraries.yaml
+++ b/libraries.yaml
@@ -43,6 +43,15 @@ yamldotnet:
   yaml-test-suite: ✓
   yaml-runtimes: ✓
 
+corvusjsonschema:
+  name: corvus-jsonschema
+  language: C#
+  homepage: https://github.com/corvus-dotnet/Corvus.JsonSchema
+  syntax:
+    1.1: ✓
+    1.2: ✓
+  yaml-test-suite: ✓
+
 hsyaml:
   name: HsYAML
   language: Haskell


### PR DESCRIPTION
Corvus.JsonSchema V5 ships a zero-allocation, high performance JSON<=>YAML converter for .NET.

It has documentation here:
https://corvus-oss.org/Corvus.JsonSchema/docs/yaml.html

An online playground here:
https://corvus-oss.org/Corvus.JsonSchema/playground-yaml/

It is 7-20x faster than YamlDotnet and has a fixed GC pressure of 136B for any conversion (zero additional allocation regardless of document size).